### PR TITLE
Upgrade Go 1.19 → 1.26.2, resolve 70 CVEs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,14 +11,14 @@ jobs:
     name: Build, test & format
     strategy:
       matrix:
-        go-version: [1.17.x, 1.18.x, 1.19.x]
+        go-version: [1.25.x, 1.26.x]
         platform: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.platform }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: setup go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v5
       with:
         go-version: ${{ matrix.go-version }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,11 +15,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Install Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v5
       with:
-        go-version: 1.19.x
+        go-version: 1.26.x
     - name: Checkout the latest code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Build
       shell: bash
       run: make release
@@ -38,11 +38,11 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Install Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v5
       with:
-        go-version: 1.19.x
+        go-version: 1.26.x
     - name: Build
       shell: bash
       run: make docker

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/micromdm/scep/v2
 
-go 1.19
+go 1.26.2
 
 require (
 	github.com/boltdb/bolt v1.3.1
@@ -20,7 +20,7 @@ require (
 	github.com/prometheus/common v0.37.0 // indirect
 	github.com/prometheus/procfs v0.8.0 // indirect
 	golang.org/x/sys v0.2.0 // indirect
-	google.golang.org/protobuf v1.28.1 // indirect
+	google.golang.org/protobuf v1.33.0 // indirect
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -118,6 +118,7 @@ github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
+github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
@@ -468,8 +469,8 @@ google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGj
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
-google.golang.org/protobuf v1.28.1 h1:d0NfwRgPtno5B1Wa6L2DAG+KivqkdutMf1UhdNx175w=
-google.golang.org/protobuf v1.28.1/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
+google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=
+google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
## Summary

- Upgrades Go toolchain from 1.19 to 1.26.2, resolving 69 stdlib CVEs (all against Go 1.19.3)
- Bumps `google.golang.org/protobuf` from v1.28.1 to v1.33.0, resolving 1 additional CVE
- Updates CI matrix to Go 1.25.x and 1.26.x; upgrades GitHub Actions to checkout@v4 and setup-go@v5

## CVEs Resolved

- 69× Go stdlib CVEs (fixed by upgrading compiler from 1.19.3)
- 1× `google.golang.org/protobuf` CVE (fixed by bumping to v1.33.0)
- Total: **70 CVEs closed**

## Jira

https://jamf.atlassian.net/browse/NOW-21933

## Blocks

NOW-21934 (now-docker repo upgrade) — unblocked once release tag is cut (see below)

## Test plan

- [ ] `go build ./...` passes locally
- [ ] `go test ./...` passes locally
- [ ] CI matrix (1.25.x, 1.26.x) passes on GitHub Actions

---

**After merge:** Cut release tag to unblock NOW-21934:
```sh
git tag v2.3.0 && git push origin v2.3.0
```
This triggers `release.yml` → builds ZIPs → creates GitHub release → `now-docker` can reference `SERVER_VERSION=2.3.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)